### PR TITLE
Refine history reset and close cleanup

### DIFF
--- a/components/ImageAnnotator.tsx
+++ b/components/ImageAnnotator.tsx
@@ -143,6 +143,7 @@ export const ImageAnnotator: React.FC<ImageAnnotatorProps> = ({ isOpen, onClose,
   const [textEditing, setTextEditing] = useState<TextEditingState | null>(null);
   const [cropRect, setCropRect] = useState<{ x: number, y: number, width: number, height: number } | null>(null);
   const actionState = useRef<{ annotation: Annotation | null, mousePos: Point, cropRect: typeof cropRect }>({ annotation: null, mousePos: { x: 0, y: 0 }, cropRect: null });
+  const wasOpenRef = useRef(false);
   const [canvasCursor, setCanvasCursor] = useState('default');
 
   const getCanvasPoint = useCallback((e: React.MouseEvent<HTMLCanvasElement> | MouseEvent): Point => {
@@ -269,12 +270,16 @@ export const ImageAnnotator: React.FC<ImageAnnotatorProps> = ({ isOpen, onClose,
   }, [history, selectedAnnotationId, tool, cropRect, drawingAnnotation, drawAnnotation]);
 
     useEffect(() => {
-        if (!isOpen || !imageFile) { 
-            resetAnnotationHistory([]); 
-            setSelectedAnnotationId(null); 
-            setCropRect(null); 
-            return; 
+    if (!isOpen || !imageFile) {
+            if (wasOpenRef.current) {
+                resetAnnotationHistory([]);
+                setSelectedAnnotationId(null);
+                setCropRect(null);
+                wasOpenRef.current = false;
+            }
+            return;
         }
+        wasOpenRef.current = true;
         const canvas = canvasRef.current; if (!canvas) return;
         const img = new Image();
         img.onload = () => {

--- a/hooks/useHistory.ts
+++ b/hooks/useHistory.ts
@@ -52,10 +52,20 @@ export const useHistory = <T>(initialState: T) => {
   }, [state]);
 
   const reset = useCallback((newInitialState: T) => {
-    setState({
-      past: [],
-      present: newInitialState,
-      future: [],
+    setState((prev) => {
+      if (
+        deepEqual(prev.present, newInitialState) &&
+        prev.past.length === 0 &&
+        prev.future.length === 0
+      ) {
+        return prev;
+      }
+
+      return {
+        past: [],
+        present: newInitialState,
+        future: [],
+      };
     });
   }, []);
 


### PR DESCRIPTION
## Summary
- avoid redundant history resets by returning previous state when nothing changes
- guard the image annotator close effect so history is cleared only after the annotator has been opened

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d01b0bd200832586193358f91e9e46